### PR TITLE
Add IndexController MockMvc test

### DIFF
--- a/src/test/java/com/example/easynotes/IndexControllerTest.java
+++ b/src/test/java/com/example/easynotes/IndexControllerTest.java
@@ -1,0 +1,32 @@
+package com.example.easynotes;
+
+import com.example.easynotes.controller.IndexController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class IndexControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private IndexController indexController;
+
+    @Test
+    public void testIndexGreeting() throws Exception {
+        String expected = indexController.sayHello();
+
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(expected));
+    }
+}


### PR DESCRIPTION
## Summary
- add a MockMvc test that verifies the index greeting

## Testing
- `./mvnw -version` *(fails: Maven wrapper jar missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f41faf5cc83218f370bd0a6e1632c